### PR TITLE
Add autoload cookies

### DIFF
--- a/pretty-mode.el
+++ b/pretty-mode.el
@@ -265,6 +265,7 @@ MODE is nil. Return nil if there are no keywords."
 (defgroup pretty nil "Minor mode for replacing text with symbols "
   :group 'faces)
 
+;;;###autoload
 (define-minor-mode pretty-mode
   "Toggle Pretty minor mode.
 With arg, turn Pretty minor mode on if arg is positive, off otherwise.
@@ -287,15 +288,17 @@ displayed as λ in lisp modes."
   (if (pretty-keywords)
       (pretty-mode 1)))
 
+;;;###autoload
 (define-globalized-minor-mode global-pretty-mode
   pretty-mode turn-on-pretty-if-desired
   :init-value t)
 
+;;;###autoload
 (defun turn-off-pretty-mode ()
   (interactive)
   (pretty-mode -1))
 
-
+;;;###autoload
 (defun turn-on-pretty-mode ()
   (interactive)
   (pretty-mode +1))


### PR DESCRIPTION
This commit ensures that users who have installed `pretty-mode` from [MELPA](http://melpa.milkbox.net/) will be able to use the code without explicitly requiring the library first. For information about this fix, See [Packaging-Basics](http://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging-Basics.html).
