### PR TITLE
use string-to-char to convert glyph for font-lock-add-keywords

### DIFF
--- a/pretty-mode.el
+++ b/pretty-mode.el
@@ -943,7 +943,7 @@ relevant buffer(s)."
                           (0 (prog1 nil
                                (compose-region (match-beginning 0)
                                                (match-end 0)
-                                               ,(cdr kw))))))
+                                               (string-to-char ,(cdr kw)))))))
                 keywords)))
 
 (defun pretty-regexp (regexp glyph)


### PR DESCRIPTION
if you check github users are trying to do things like:

  (pretty-add-keywords 'js3-mode `(("true"      . "т")...

But it won't work as expected.